### PR TITLE
Add subcommand modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "cargo-typesize"
-version = "0.1.0"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-typesize"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Cargo extension to list size of all types in a crate"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,11 +62,12 @@ impl TypeSizeCmd {
                     continue;
                 }
                 "check" => {
-                    cargo_subcommand = "check --no-run";
+                    cargo_subcommand = "check";
                     continue;
                 }
                 "test" => {
                     cargo_subcommand = "test";
+                    args.push("--no-run".to_string());
                     continue;
                 }
                 "--" => break,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,9 @@ Usage:
     cargo typesize [options] [--] [<opts>...]
 
 Options:
-    --build                  Run with cargo build
-    --check                  Run with cargo check (default)
-    --test                   Run with cargo test
+    build                    Run with cargo build
+    check                    Run with cargo check (default)
+    test                     Run with cargo test
     -h, --help               Print this message
     -V, --version            Print version info and exit
 "#;
@@ -52,27 +52,27 @@ struct TypeSizeCmd {
 impl TypeSizeCmd {
     fn new(old_args: impl Iterator<Item = String>) -> Self {
         let mut cargo_subcommand = "check";
-        let args = vec![];
-        let mut typesize_args: Vec<String> = vec![];
+        let mut args = vec![];
+        let typesize_args: Vec<String> = vec![];
 
         for arg in old_args {
             match arg.as_str() {
-                "--build" => {
+                "build" => {
                     cargo_subcommand = "build";
                     continue;
                 }
-                "--check" => {
-                    cargo_subcommand = "check";
+                "check" => {
+                    cargo_subcommand = "check --no-run";
                     continue;
                 }
-                "--test" => {
+                "test" => {
                     cargo_subcommand = "test";
                     continue;
                 }
                 "--" => break,
                 _ => {}
             }
-            typesize_args.push(arg);
+            args.push(arg);
         }
 
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,16 +10,31 @@ const CARGO_TYPESIZE_HELP: &str = r#"Lists type sizes for all types in a package
 
 Usage:
     cargo typesize [options] [--] [<opts>...]
+
+Options:
+    --build                  Run with cargo build
+    --check                  Run with cargo check (default)
+    --test                   Run with cargo test
+    -h, --help               Print this message
+    -V, --version            Print version info and exit
 "#;
 
 fn show_help() {
     println!("{}", CARGO_TYPESIZE_HELP);
 }
 
+fn show_version() {
+    println!("{} {}", env!("CARGO_BIN_NAME"), env!("CARGO_PKG_VERSION"));
+}
+
 pub fn main() {
-    // Check for version and help flags even when invoked as 'cargo-clippy'
     if env::args().any(|a| a == "--help" || a == "-h") {
         show_help();
+        return;
+    }
+
+    if env::args().any(|a| a == "--version" || a == "-V") {
+        show_version();
         return;
     }
 
@@ -36,11 +51,29 @@ struct TypeSizeCmd {
 
 impl TypeSizeCmd {
     fn new(old_args: impl Iterator<Item = String>) -> Self {
-        let cargo_subcommand = "check";
+        let mut cargo_subcommand = "check";
         let args = vec![];
         let mut typesize_args: Vec<String> = vec![];
 
-        typesize_args.extend(old_args);
+        for arg in old_args {
+            match arg.as_str() {
+                "--build" => {
+                    cargo_subcommand = "build";
+                    continue;
+                }
+                "--check" => {
+                    cargo_subcommand = "check";
+                    continue;
+                }
+                "--test" => {
+                    cargo_subcommand = "test";
+                    continue;
+                }
+                "--" => break,
+                _ => {}
+            }
+            typesize_args.push(arg);
+        }
 
         Self {
             cargo_subcommand,


### PR DESCRIPTION
* Allow alternate subcommand modes (`build` and `test`)
* Default to (original) `cargo check` operation
* Show version

Basic run mode operation implementation based on #2 feature proposal.

